### PR TITLE
feat: Implement layering system for TOP slot

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,6 +77,7 @@ dependencies {
     implementation(libs.camerax.lifecycle)
     implementation(libs.camerax.view)
     implementation(libs.accompanist.permissions)
+    implementation(libs.reorderable)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/java/net/ottercloud/sliderschrank/data/model/Enums.kt
+++ b/app/src/main/java/net/ottercloud/sliderschrank/data/model/Enums.kt
@@ -47,5 +47,10 @@ enum class Slot {
     TOP,
     BOTTOM,
     FEET,
-    ACCESSORY
+    ACCESSORY;
+
+    fun supportsLayers(): Boolean {
+        // Currently only TOP slot supports layering
+        return this == TOP
+    }
 }

--- a/app/src/main/java/net/ottercloud/sliderschrank/ui/homescreen/GarmentSliders.kt
+++ b/app/src/main/java/net/ottercloud/sliderschrank/ui/homescreen/GarmentSliders.kt
@@ -67,7 +67,12 @@ fun GarmentSliders(
                     onPieceClick = { onSelectSlot(it.piece.slot) },
                     modifier = Modifier
                         .weight(weight)
-                        .fillMaxWidth()
+                        .fillMaxWidth(),
+                    backgroundLayers = if (slot.supportsLayers()) {
+                        state.backgroundLayers
+                    } else {
+                        emptyList()
+                    }
                 )
             }
         }

--- a/app/src/main/java/net/ottercloud/sliderschrank/ui/homescreen/HomeScreenState.kt
+++ b/app/src/main/java/net/ottercloud/sliderschrank/ui/homescreen/HomeScreenState.kt
@@ -32,31 +32,51 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import net.ottercloud.sliderschrank.data.model.OutfitWithPieces
 import net.ottercloud.sliderschrank.data.model.PieceWithDetails
 import net.ottercloud.sliderschrank.data.model.Slot
 
 @OptIn(ExperimentalFoundationApi::class)
 class HomeScreenState(
-    val groupedPieces: Map<Slot, List<PieceWithDetails>>,
+    initialGroupedPieces: Map<Slot, List<PieceWithDetails>>,
     val pagerStates: Map<Slot, PagerState>,
-    val savedOutfits: List<OutfitWithPieces>,
-    private val onToggleFavorite: (List<OutfitWithPieces>, Set<Long>) -> Unit
+    initialSavedOutfits: List<OutfitWithPieces>,
+    private val scope: CoroutineScope
 ) {
+    var groupedPieces by mutableStateOf(initialGroupedPieces)
+    var savedOutfits by mutableStateOf(initialSavedOutfits)
+
+    private val allPiecesLookup by derivedStateOf {
+        groupedPieces.values.asSequence().flatten().associateBy { it.piece.id }
+    }
+
     var lockedPieceIds by mutableStateOf(emptySet<Long>())
-        private set
+
+    // Layers for the supported slot (underneath the active one)
+    private var backgroundLayerIds by mutableStateOf(emptyList<Long>())
+
+    val backgroundLayers: List<PieceWithDetails> by derivedStateOf {
+        backgroundLayerIds.mapNotNull { allPiecesLookup[it] }
+    }
 
     val currentOutfitIds by derivedStateOf {
-        pagerStates.mapNotNull { (slot, pagerState) ->
+        val baseIds = pagerStates.mapNotNull { (slot, pagerState) ->
             val pieceId = groupedPieces[slot]?.getOrNull(pagerState.currentPage)?.piece?.id
             // Filter out the empty HEAD piece (id = -1)
             if (pieceId != null && pieceId != -1L) pieceId else null
         }.toSet()
+
+        (baseIds + backgroundLayerIds).toSet()
     }
 
     val isCurrentOutfitSaved by derivedStateOf {
@@ -74,8 +94,82 @@ class HomeScreenState(
         }
     }
 
-    fun onFavoriteClick() {
+    fun onFavoriteClick(onToggleFavorite: (List<OutfitWithPieces>, Set<Long>) -> Unit) {
         onToggleFavorite(savedOutfits, currentOutfitIds)
+    }
+
+    fun getVisibleLayers(): List<PieceWithDetails> {
+        val activePiece = getActiveLayeredPiece()
+        return if (activePiece != null) backgroundLayers + activePiece else backgroundLayers
+    }
+
+    fun addLayer() {
+        val activePiece = getActiveLayeredPiece()
+        if (activePiece != null) {
+            // Move current active to background, keep active as is (duplicate for moment until user slides)
+            // Or pick a default?
+            backgroundLayerIds = backgroundLayerIds + activePiece.piece.id
+        }
+    }
+
+    fun removeLayer(index: Int) {
+        val currentLayers = getVisibleLayers()
+        if (index in currentLayers.indices) {
+            val newLayers = currentLayers.toMutableList().apply { removeAt(index) }
+            updateLayers(newLayers)
+        }
+    }
+
+    fun reorderLayers(from: Int, to: Int) {
+        val currentLayers = getVisibleLayers().toMutableList()
+        if (from in currentLayers.indices && to in currentLayers.indices) {
+            val item = currentLayers.removeAt(from)
+            currentLayers.add(to, item)
+            updateLayers(currentLayers)
+        }
+    }
+
+    fun updateLayerPiece(index: Int, newPiece: PieceWithDetails) {
+        val currentLayers = getVisibleLayers().toMutableList()
+        if (index in currentLayers.indices) {
+            currentLayers[index] = newPiece
+            updateLayers(currentLayers)
+        }
+    }
+
+    fun setLayers(layers: List<PieceWithDetails>) {
+        updateLayers(layers)
+    }
+
+    internal fun getBackgroundLayerIds(): List<Long> = backgroundLayerIds
+
+    internal fun setBackgroundLayerIds(ids: List<Long>) {
+        backgroundLayerIds = ids
+    }
+
+    private fun getActiveLayeredPiece(): PieceWithDetails? {
+        val slot = Slot.entries.firstOrNull { it.supportsLayers() } ?: return null
+        return groupedPieces[slot]?.getOrNull(pagerStates[slot]?.currentPage ?: 0)
+    }
+
+    private fun updateLayers(layers: List<PieceWithDetails>) {
+        if (layers.isEmpty()) {
+            backgroundLayerIds = emptyList()
+            return
+        }
+
+        val newActive = layers.last()
+        backgroundLayerIds = layers.dropLast(1).map { it.piece.id }
+
+        // Sync Pager
+        val slot = Slot.entries.firstOrNull { it.supportsLayers() } ?: return
+        val topPieces = groupedPieces[slot] ?: return
+        val index = topPieces.indexOfFirst { it.piece.id == newActive.piece.id }
+        if (index != -1) {
+            scope.launch {
+                pagerStates[slot]?.scrollToPage(index)
+            }
+        }
     }
 }
 
@@ -84,21 +178,58 @@ class HomeScreenState(
 fun rememberHomeScreenState(
     groupedPieces: Map<Slot, List<PieceWithDetails>>,
     savedOutfits: List<OutfitWithPieces>,
-    onToggleFavorite: (List<OutfitWithPieces>, Set<Long>) -> Unit
+    scope: CoroutineScope = rememberCoroutineScope()
 ): HomeScreenState {
     val pagerStates = getSlotOrder().associateWith { slot ->
         val piecesForSlot = groupedPieces[slot].orEmpty()
         rememberPagerState(pageCount = { piecesForSlot.size })
     }
 
-    return remember(groupedPieces, pagerStates, savedOutfits, onToggleFavorite) {
+    val saver = Saver<HomeScreenState, Map<String, Any>>(
+        save = { state ->
+            mapOf(
+                "locked" to state.lockedPieceIds.toList(),
+                "layers" to state.getBackgroundLayerIds()
+            )
+        },
+        restore = { map ->
+            // Restore IDs safely
+            @Suppress("UNCHECKED_CAST")
+            val lockedIds = (map["locked"] as? List<Long>)?.toSet() ?: emptySet()
+
+            @Suppress("UNCHECKED_CAST")
+            val layerIds = map["layers"] as? List<Long> ?: emptyList()
+
+            HomeScreenState(
+                initialGroupedPieces = groupedPieces,
+                pagerStates = pagerStates,
+                initialSavedOutfits = savedOutfits,
+                scope = scope
+            ).apply {
+                this.lockedPieceIds = lockedIds
+                this.setBackgroundLayerIds(layerIds)
+            }
+        }
+    )
+
+    val state = rememberSaveable(saver = saver) {
         HomeScreenState(
-            groupedPieces = groupedPieces,
+            initialGroupedPieces = groupedPieces,
             pagerStates = pagerStates,
-            savedOutfits = savedOutfits,
-            onToggleFavorite = onToggleFavorite
+            initialSavedOutfits = savedOutfits,
+            scope = scope
         )
     }
+
+    LaunchedEffect(groupedPieces) {
+        state.groupedPieces = groupedPieces
+    }
+
+    LaunchedEffect(savedOutfits) {
+        state.savedOutfits = savedOutfits
+    }
+
+    return state
 }
 
 fun getSlotOrder(): List<Slot> = listOf(Slot.HEAD, Slot.TOP, Slot.BOTTOM, Slot.FEET)

--- a/app/src/main/java/net/ottercloud/sliderschrank/ui/homescreen/HomeScreenState.kt
+++ b/app/src/main/java/net/ottercloud/sliderschrank/ui/homescreen/HomeScreenState.kt
@@ -159,16 +159,21 @@ class HomeScreenState(
         }
 
         val newActive = layers.last()
-        backgroundLayerIds = layers.dropLast(1).map { it.piece.id }
 
-        // Sync Pager
+        // Resolve the slot and index before mutating state to keep pager and layers in sync.
         val slot = Slot.entries.firstOrNull { it.supportsLayers() } ?: return
         val topPieces = groupedPieces[slot] ?: return
         val index = topPieces.indexOfFirst { it.piece.id == newActive.piece.id }
-        if (index != -1) {
-            scope.launch {
-                pagerStates[slot]?.scrollToPage(index)
-            }
+        if (index == -1) {
+            // newActive is not present in the available pieces; avoid desynchronizing state.
+            return
+        }
+
+        backgroundLayerIds = layers.dropLast(1).map { it.piece.id }
+
+        // Sync Pager
+        scope.launch {
+            pagerStates[slot]?.scrollToPage(index)
         }
     }
 }

--- a/app/src/main/java/net/ottercloud/sliderschrank/ui/homescreen/LayerView.kt
+++ b/app/src/main/java/net/ottercloud/sliderschrank/ui/homescreen/LayerView.kt
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2025 OtterCloud
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.ottercloud.sliderschrank.ui.homescreen
+
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.DragHandle
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import net.ottercloud.sliderschrank.R
+import net.ottercloud.sliderschrank.data.model.PieceWithDetails
+import sh.calvin.reorderable.ReorderableItem
+import sh.calvin.reorderable.rememberReorderableLazyListState
+
+private data class UiLayer(val uniqueId: String, val piece: PieceWithDetails)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LayerView(
+    layers: List<PieceWithDetails>,
+    onReorder: (Int, Int) -> Unit,
+    onDelete: (Int) -> Unit,
+    onAdd: () -> Unit,
+    onSelectLayer: (Int) -> Unit,
+    onDismiss: () -> Unit
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.layers),
+                style = MaterialTheme.typography.titleLarge
+            )
+
+            // Deduplicate items with unique IDs
+            val uiLayers = remember(layers) {
+                val counts = mutableMapOf<Long, Int>()
+                layers.asReversed().map { pieceWithDetails ->
+                    val id = pieceWithDetails.piece.id
+                    val count = counts.getOrDefault(id, 0)
+                    counts[id] = count + 1
+                    UiLayer("${id}_$count", pieceWithDetails)
+                }
+            }
+
+            // Local list to handle smooth animations during drag
+            var localLayers by remember { mutableStateOf(uiLayers) }
+
+            LaunchedEffect(uiLayers) {
+                localLayers = uiLayers
+            }
+
+            val lazyListState = rememberLazyListState()
+            val reorderableState = rememberReorderableLazyListState(lazyListState) { from, to ->
+                // Update local list
+                localLayers = localLayers.toMutableList().apply {
+                    add(to.index, removeAt(from.index))
+                }
+
+                // Map visual index back to data index
+                val realFrom = layers.lastIndex - from.index
+                val realTo = layers.lastIndex - to.index
+                onReorder(realFrom, realTo)
+            }
+
+            LazyColumn(
+                state = lazyListState,
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                itemsIndexed(localLayers, key = { _, item -> item.uniqueId }) { index, uiLayer ->
+                    ReorderableItem(reorderableState, key = uiLayer.uniqueId) { isDragging ->
+                        val elevation by animateDpAsState(if (isDragging) 8.dp else 0.dp)
+
+                        // Calculate real index for callbacks
+                        // Since localLayers is always synced with layers (outside of drag),
+                        // and localLayers is reversed layers, we can map directly.
+                        val realIndex = layers.lastIndex - index
+
+                        LayerItem(
+                            piece = uiLayer.piece,
+                            onDelete = { if (realIndex in layers.indices) onDelete(realIndex) },
+                            onClick = { if (realIndex in layers.indices) onSelectLayer(realIndex) },
+                            modifier = Modifier
+                                .shadow(elevation)
+                                .background(MaterialTheme.colorScheme.surface),
+                            dragHandleModifier = Modifier.draggableHandle(),
+                            isActive = realIndex == layers.lastIndex // Visual Top is Data Last
+                        )
+                    }
+                }
+            }
+
+            Button(
+                onClick = onAdd,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Icon(Icons.Default.Add, contentDescription = null)
+                Text(
+                    text = stringResource(R.string.add_layer),
+                    modifier = Modifier.padding(start = 8.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun LayerItem(
+    piece: PieceWithDetails,
+    onDelete: () -> Unit,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    dragHandleModifier: Modifier = Modifier,
+    isActive: Boolean = false
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        onClick = onClick,
+        colors = if (isActive) {
+            CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.primaryContainer
+            )
+        } else {
+            CardDefaults.cardColors()
+        }
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            // Drag handle
+            Icon(
+                Icons.Default.DragHandle,
+                contentDescription = stringResource(R.string.reorder_layer),
+                modifier = dragHandleModifier
+                    .size(24.dp)
+            )
+
+            // Image
+            AsyncImage(
+                model = piece.piece.imageUrl,
+                contentDescription = null,
+                modifier = Modifier
+                    .size(64.dp)
+                    .background(MaterialTheme.colorScheme.surfaceVariant),
+                contentScale = ContentScale.Crop
+            )
+
+            // Info
+            Text(
+                text = piece.category?.name ?: stringResource(R.string.clothes),
+                modifier = Modifier.weight(1f),
+                style = MaterialTheme.typography.bodyMedium
+            )
+
+            // Delete
+            IconButton(onClick = onDelete) {
+                Icon(
+                    Icons.Default.Delete,
+                    contentDescription = stringResource(R.string.remove_layer)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/net/ottercloud/sliderschrank/ui/homescreen/PiecePickerDialog.kt
+++ b/app/src/main/java/net/ottercloud/sliderschrank/ui/homescreen/PiecePickerDialog.kt
@@ -69,7 +69,8 @@ fun PiecePickerDialog(
     state: HomeScreenState,
     scope: CoroutineScope,
     database: AppDatabase?,
-    onDismiss: () -> Unit
+    onDismiss: () -> Unit,
+    onPieceSelect: ((PieceWithDetails) -> Unit)? = null
 ) {
     Dialog(
         onDismissRequest = onDismiss,
@@ -105,13 +106,17 @@ fun PiecePickerDialog(
                     imageUrlProvider = { it.piece.imageUrl },
                     tagProvider = { it.tags.map { tag -> tag.name } },
                     onItemClick = { pieceWithDetails ->
-                        val targetIndex = state.groupedPieces[slot]
-                            ?.indexOfFirst { it.piece.id == pieceWithDetails.piece.id }
-                            ?: -1
+                        if (onPieceSelect != null) {
+                            onPieceSelect(pieceWithDetails)
+                        } else {
+                            val targetIndex = state.groupedPieces[slot]
+                                ?.indexOfFirst { it.piece.id == pieceWithDetails.piece.id }
+                                ?: -1
 
-                        if (targetIndex >= 0) {
-                            scope.launch {
-                                state.pagerStates[slot]?.animateScrollToPage(targetIndex)
+                            if (targetIndex >= 0) {
+                                scope.launch {
+                                    state.pagerStates[slot]?.animateScrollToPage(targetIndex)
+                                }
                             }
                         }
                         onDismiss()

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -49,6 +49,7 @@
     <string name="failed_to_save_outfit_please_try_again">Outfit konnte nicht gespeichert werden. Versuche es erneut!</string>
     <string name="clothes">Klamotten</string>
     <string name="outfits">Outfits</string>
+    <string name="reorder_layer">Schicht neu anordnen</string>
     <string name="select_slot">%s auswählen</string>
     <string name="none">Nichts</string>
     <string name="slot_head">Kopf</string>
@@ -56,4 +57,7 @@
     <string name="slot_bottom">Unterteil</string>
     <string name="slot_feet">Füße</string>
     <string name="slot_accessory">Accessoire</string>
+    <string name="layers">Schichten</string>
+    <string name="add_layer">Schicht hinzufügen</string>
+    <string name="remove_layer">Schicht entfernen</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,6 +49,10 @@
     <string name="failed_to_save_outfit_please_try_again">Failed to save outfit. Please try again.</string>
     <string name="clothes">Clothes</string>
     <string name="outfits">Outfits</string>
+    <string name="layers">Layers</string>
+    <string name="add_layer">Add Layer</string>
+    <string name="remove_layer">Remove Layer</string>
+    <string name="reorder_layer">Reorder Layer</string>
     <string name="select_slot">Select %s</string>
     <string name="none">None</string>
     <string name="slot_head">Head</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ ksp = "2.3.0"
 camerax = "1.5.2"
 accompanist = "0.37.3"
 coil = "2.7.0"
+reorderable = "2.4.3"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -47,6 +48,7 @@ camerax-camera2 = { group = "androidx.camera", name = "camera-camera2", version.
 camerax-lifecycle = { group = "androidx.camera", name = "camera-lifecycle", version.ref = "camerax" }
 camerax-view = { group = "androidx.camera", name = "camera-view", version.ref = "camerax" }
 accompanist-permissions = { group = "com.google.accompanist", name = "accompanist-permissions", version.ref = "accompanist" }
+reorderable = { group = "sh.calvin.reorderable", name = "reorderable", version.ref = "reorderable" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
closes #20 
This introduces a layering system, initially for the "TOP" clothing slot.

- Adds a new `LayerView.kt` modal bottom sheet to manage layers.
- Users can add, remove, and reorder layers within this dialog.
- The active (topmost) layer is visually distinct.
- `HomeScreen` now shows the `LayerView` dialog when the `TOP` garment is clicked. Clicking other slots continues to open the piece picker directly.
- The `GarmentSlider` for the `TOP` slot now visually displays the underlying layers as a stacked-and-offset collection of images.
- `HomeScreenState` is significantly refactored to manage layer state, including adding, removing, reordering, and saving/restoring the layer configuration.
- Adds the `sh.calvin.reorderable` library to enable drag-and-drop reordering in the `LayerView`.